### PR TITLE
Hotfix: Incorrect height for sliders

### DIFF
--- a/inc/classes/blocks/class-jetpack-slideshow.php
+++ b/inc/classes/blocks/class-jetpack-slideshow.php
@@ -96,11 +96,7 @@ class Jetpack_Slideshow {
 		// Loads block's required bento front-end scripts & styles.
 		$this->enqueue_block_assets();
 
-		if ( is_bento( $this->block_attributes ) ) {
-			return (string) $this->render_bento( $block_content );
-		}
-
-		return $block_content;
+		return (string) $this->render_bento( $block_content );
 	}
 
 	/**
@@ -144,10 +140,14 @@ class Jetpack_Slideshow {
 		$autoplay    = empty( $this->block_attributes['autoplay'] ) ? false : $this->block_attributes['autoplay'];
 		$width       = empty( $first_image['width'] ) ? 800 : $first_image['width'];
 		$height      = empty( $first_image['height'] ) ? 600 : $first_image['height'];
-		$style       = "height: {$height}px;";
+		$style       = '';
+
+		if ( ! \is_amp_request() ) {
+			$style = "aspect-ratio: {$width}/{$height}";
+		}
 
 		return sprintf(
-			'<bento-base-carousel width="%1$d" height="%2$d" style="%3$s" data-next-button-aria-label="%4$s" data-prev-button-aria-label="%5$s" %6$s id="wp-block-jetpack-slideshow__amp-base-carousel__%7$s" loop>%8$s</bento-base-carousel>',
+			'<bento-base-carousel layout="responsive" width="%1$d" height="%2$d" style="%3$s" data-next-button-aria-label="%4$s" data-prev-button-aria-label="%5$s" %6$s id="wp-block-jetpack-slideshow__amp-base-carousel__%7$s" loop>%8$s</bento-base-carousel>',
 			esc_attr( $width ),
 			esc_attr( $height ),
 			esc_attr( $style ),


### PR DESCRIPTION
## Context
- Previously used `amp-base-carousel (1.0)` used to take height dynamically, whereas the `bento-base-carousel` component requires fixed height or styling to support it determine the height of the Slider.
- For that reason, the first image's height was being used for setting the sliders' heights. Which caused some unexpected behavior as the height of the image we get isn't what's going to be rendered and is the original height of the image uploaded.

## Summary
- The PR, on non-AMP pages, uses the `aspect-ratio` CSS property to based on the initial `height` & `width` attributes of an image uploaded for setting the carousel's dimensions.
- For AMP pages, using the responsive layout will automatically adjust the height of the sliders.

## Relevant Technical Choices
_None_

## To-do
_None_

## Screenshots/Screenshares
_None_
